### PR TITLE
Throwaway gmail address for dev

### DIFF
--- a/packages/server/src/config/email.config.ts
+++ b/packages/server/src/config/email.config.ts
@@ -2,7 +2,7 @@ import { HandlebarsAdapter } from "@nest-modules/mailer";
 
 const transport =
     process.env.EMAIL_CONNECTION_URL ||
-    "smtps://angrykoolaidman@gmail.com:<password>@smtp.gmail.com"; //More info on connection urls here: https://nodemailer.com/smtp/ and https://nodemailer.com/usage/using-gmail/
+    "smtps://unfrltempcarpool@gmail.com:testpass117@smtp.gmail.com"; //More info on connection urls here: https://nodemailer.com/smtp/ and https://nodemailer.com/usage/using-gmail/
 export const emailConfig: any = {
     transport,
     defaults: {


### PR DESCRIPTION
Closes #62 
Now our email.config has a throwaway gmail account so we dont have to worry about hiding it or anything during development. As you can see it has a super secure password nobody will ever be able to crack