### PR TITLE
Ability to edit carpool details

### DIFF
--- a/packages/core/src/stores/carpool.store.ts
+++ b/packages/core/src/stores/carpool.store.ts
@@ -29,7 +29,7 @@ export class CarpoolStore {
     }
 
     @observable
-    public creating: boolean = false;
+    public saving: boolean = false;
 
     @observable
     public loading: boolean = false;
@@ -50,7 +50,7 @@ export class CarpoolStore {
      */
     public createCarpool = async (carpoolDto: CarpoolDto): Promise<Carpool> => {
         try {
-            this.setCreating(true);
+            this.setSaving(true);
 
             const carpool = await this._rootStore.carpoolClient.createCarpool(carpoolDto);
 
@@ -61,7 +61,7 @@ export class CarpoolStore {
             this._logger.error("Failed to create carpool", error);
             throw error;
         } finally {
-            this.setCreating(false);
+            this.setSaving(false);
         }
     };
 
@@ -122,8 +122,8 @@ export class CarpoolStore {
     };
 
     @action
-    private setCreating = (creating: boolean) => {
-        this.creating = creating;
+    private setSaving = (creating: boolean) => {
+        this.saving = creating;
     };
 
     @action

--- a/packages/core/src/stores/carpool.store.ts
+++ b/packages/core/src/stores/carpool.store.ts
@@ -150,8 +150,8 @@ export class CarpoolStore {
     };
 
     @action
-    private setSaving = (creating: boolean) => {
-        this.saving = creating;
+    private setSaving = (saving: boolean) => {
+        this.saving = saving;
     };
 
     @action

--- a/packages/core/src/stores/carpool.store.ts
+++ b/packages/core/src/stores/carpool.store.ts
@@ -66,6 +66,26 @@ export class CarpoolStore {
     };
 
     /**
+     * Updates an existing carpool and then updates the carpool in the collection if successful
+     */
+    public updateCarpool = async (carpoolDto: CarpoolDto, carpoolId: string) => {
+        try {
+            this.setSaving(true);
+
+            const carpool = await this._rootStore.carpoolClient.updateCarpool(
+                carpoolDto,
+                carpoolId
+            );
+
+            this.setUpdatedCarpool(carpool);
+        } catch (error) {
+            this._logger.error("Failed to update carpool", error);
+        } finally {
+            this.setSaving(false);
+        }
+    };
+
+    /**
      * Sets the selected carpool ID, first checking if it has the carpool locally. If not, it'll attempt to fetch it from the server.
      */
     public selectCarpool = async (carpoolId: string) => {
@@ -119,6 +139,14 @@ export class CarpoolStore {
     @action
     private setCarpools = (carpools: Carpool[]) => {
         this.carpools = carpools;
+    };
+
+    @action
+    private setUpdatedCarpool = (carpool: Carpool) => {
+        const index = this.carpools.findIndex(c => c.id === carpool.id);
+        if (index > -1) {
+            this.carpools[index] = carpool;
+        }
     };
 
     @action

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -65,7 +65,7 @@ export class App extends Component<IAppProps, IAppState> {
     }
 
     public render() {
-        const { authStore, carpoolStore, driverStore } = this.injectedProps;
+        const { authStore, carpoolStore, driverStore, routerStore } = this.injectedProps;
 
         return (
             <ThemeProvider theme={theme}>
@@ -78,12 +78,13 @@ export class App extends Component<IAppProps, IAppState> {
                         <Route
                             path="/create-carpool"
                             exact={true}
-                            render={_routeProps => (
+                            render={routeProps => (
                                 <CreateCarpoolScreen
                                     initialized={authStore.initialized}
                                     isAuthenticated={authStore.isAuthenticated}
                                     onSignIn={this.handleAuthClick}
                                     carpoolStore={carpoolStore}
+                                    routerStore={routerStore}
                                 />
                             )}
                         />

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -78,7 +78,7 @@ export class App extends Component<IAppProps, IAppState> {
                         <Route
                             path="/create-carpool"
                             exact={true}
-                            render={routeProps => (
+                            render={_routeProps => (
                                 <CreateCarpoolScreen
                                     initialized={authStore.initialized}
                                     isAuthenticated={authStore.isAuthenticated}

--- a/packages/web/src/components/carpool-details.tsx
+++ b/packages/web/src/components/carpool-details.tsx
@@ -1,6 +1,15 @@
-import React, { FunctionComponent } from "react";
-import { IconButton, Icon, Card, CardHeader, Typography } from "@material-ui/core";
+import React, { FunctionComponent, useState } from "react";
+import { IconButton, Icon, Card, CardHeader, Typography, makeStyles } from "@material-ui/core";
 import moment from "moment";
+
+import { CarpoolDto } from "@carpool/core";
+import { CarpoolForm } from ".";
+
+const useStyles = makeStyles(theme => ({
+    form: {
+        padding: theme.spacing(2),
+    },
+}));
 
 export interface ICarpoolDetailsProps {
     /**
@@ -15,29 +24,71 @@ export interface ICarpoolDetailsProps {
      * Date of the carpool.
      */
     date: Date;
+    /**
+     * Set to true of the user can edit the carpool details.
+     */
+    canEdit: boolean;
+    /**
+     * Callback for saving edits made to the carpool. Note: this callback won't be invoked if `canEdit` is set to false.
+     */
+    onSave: (carpoolDto: CarpoolDto) => Promise<void>;
+    /**
+     * Set to true if the carpool is being saved.
+     */
+    saving: boolean;
 }
 
 export const CarpoolDetails: FunctionComponent<ICarpoolDetailsProps> = props => {
-    const { name, destination, date } = props;
+    const classes = useStyles();
+    const [editing, setEditing] = useState(false);
+    const { name, destination, date, canEdit, onSave, saving } = props;
+
+    const handleSave = async (carpoolDto: CarpoolDto) => {
+        if (canEdit) {
+            await onSave(carpoolDto);
+            handleToggleEditing();
+        }
+    };
+
+    const handleToggleEditing = () => {
+        setEditing(!editing);
+    };
 
     return (
         <Card>
-            <CardHeader
-                title={name}
-                subheader={
-                    <div>
-                        <Typography>{destination}</Typography>
-                        <Typography>
-                            {moment(new Date(date)).format("dddd, MMMM Do YYYY, h:mm a")}
-                        </Typography>
-                    </div>
-                }
-                action={
-                    <IconButton title="Edit">
-                        <Icon>edit</Icon>
-                    </IconButton>
-                }
-            />
+            {editing && canEdit ? (
+                <div className={classes.form}>
+                    <CarpoolForm
+                        onSave={handleSave}
+                        onCancel={handleToggleEditing}
+                        saving={saving}
+                        existingCarpool={{
+                            carpoolName: name,
+                            destination: destination,
+                            dateTime: date,
+                        }}
+                    />
+                </div>
+            ) : (
+                <CardHeader
+                    title={name}
+                    subheader={
+                        <div>
+                            <Typography>{destination}</Typography>
+                            <Typography>
+                                {moment(new Date(date)).format("dddd, MMMM Do YYYY, h:mm a")}
+                            </Typography>
+                        </div>
+                    }
+                    action={
+                        canEdit && (
+                            <IconButton title="Edit" onClick={handleToggleEditing}>
+                                <Icon>edit</Icon>
+                            </IconButton>
+                        )
+                    }
+                />
+            )}
         </Card>
     );
 };

--- a/packages/web/src/components/carpool-form.tsx
+++ b/packages/web/src/components/carpool-form.tsx
@@ -19,9 +19,21 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export interface ICarpoolFormProps {
+    /**
+     * Callback requesting the carpool be saved.
+     */
     onSave: (carpoolDto: CarpoolDto) => void;
+    /**
+     * Callback requesting to cancel.
+     */
     onCancel: () => void;
+    /**
+     * Set to true to disable buttons and display loading indicator.
+     */
     saving: boolean;
+    /**
+     * Provide an existing carpool to toggle the form as an "edit" not a "create".
+     */
     existingCarpool?: CarpoolDto;
 }
 

--- a/packages/web/src/components/carpool-form.tsx
+++ b/packages/web/src/components/carpool-form.tsx
@@ -2,7 +2,8 @@ import React, { FunctionComponent, useState } from "react";
 import { TextField, Button, makeStyles } from "@material-ui/core";
 import { DateTimePicker } from "@material-ui/pickers";
 
-import { NavLink, AddressSearch, LoadingButton } from ".";
+import { CarpoolDto } from "@carpool/core";
+import { AddressSearch, LoadingButton } from ".";
 
 const useStyles = makeStyles(theme => ({
     actions: {
@@ -18,31 +19,33 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export interface ICarpoolFormProps {
-    onCreate: (name: string, date: Date, address: string) => void;
-    creating: boolean;
+    onSave: (carpoolDto: CarpoolDto) => void;
+    onCancel: () => void;
+    saving: boolean;
+    existingCarpool?: CarpoolDto;
 }
 
-export interface ICarpoolFormState {
-    name: string;
-    date: Date;
-    address: string;
-}
+export interface ICarpoolFormState extends CarpoolDto {}
 
 export const CarpoolForm: FunctionComponent<ICarpoolFormProps> = props => {
     const classes = useStyles();
-    const [state, setState] = useState<ICarpoolFormState>({
-        name: "",
-        date: new Date(),
-        address: "",
-    });
+    const { existingCarpool } = props;
+    const [state, setState] = useState<ICarpoolFormState>(
+        existingCarpool || {
+            carpoolName: "",
+            dateTime: new Date(),
+            destination: "",
+        }
+    );
 
-    const canCreate = Boolean(state.name && state.date && state.address);
+    const isEditing = !!existingCarpool;
+    const canSave = Boolean(state.carpoolName && state.dateTime && state.destination);
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
 
-        if (canCreate) {
-            props.onCreate(state.name, state.date, state.address);
+        if (canSave) {
+            props.onSave(state);
         }
     };
 
@@ -50,8 +53,8 @@ export const CarpoolForm: FunctionComponent<ICarpoolFormProps> = props => {
         <form onSubmit={handleSubmit}>
             <TextField
                 label="Name"
-                value={state.name}
-                onChange={e => setState({ ...state, name: e.target.value })}
+                value={state.carpoolName}
+                onChange={e => setState({ ...state, carpoolName: e.target.value })}
                 variant="outlined"
                 margin="normal"
                 fullWidth={true}
@@ -59,13 +62,13 @@ export const CarpoolForm: FunctionComponent<ICarpoolFormProps> = props => {
                 autoFocus={true}
             />
             <AddressSearch
-                value={state.address}
-                onChange={val => setState({ ...state, address: val })}
+                value={state.destination}
+                onChange={val => setState({ ...state, destination: val })}
                 required={true}
             />
             <DateTimePicker
-                value={state.date}
-                onChange={date => date && setState({ ...state, date: date.toDate() })}
+                value={state.dateTime}
+                onChange={date => date && setState({ ...state, dateTime: date.toDate() })}
                 format="MM/DD/YYYY, hh:mm a"
                 inputVariant="outlined"
                 label="Date"
@@ -78,15 +81,13 @@ export const CarpoolForm: FunctionComponent<ICarpoolFormProps> = props => {
                 <LoadingButton
                     color="primary"
                     type="submit"
-                    disabled={!canCreate}
-                    text="Create"
-                    loading={props.creating}
+                    disabled={!canSave}
+                    text={isEditing ? "Save" : "Create"}
+                    loading={props.saving}
                 />
-                <NavLink to="/">
-                    <Button variant="text" className={classes.cancel}>
-                        Cancel
-                    </Button>
-                </NavLink>
+                <Button variant="text" className={classes.cancel} onClick={props.onCancel}>
+                    Cancel
+                </Button>
             </div>
         </form>
     );

--- a/packages/web/src/components/carpool-form.tsx
+++ b/packages/web/src/components/carpool-form.tsx
@@ -43,11 +43,14 @@ export const CarpoolForm: FunctionComponent<ICarpoolFormProps> = props => {
     const classes = useStyles();
     const { existingCarpool } = props;
     const [state, setState] = useState<ICarpoolFormState>(
-        existingCarpool || {
-            carpoolName: "",
-            dateTime: new Date(),
-            destination: "",
-        }
+        Object.assign(
+            {},
+            existingCarpool || {
+                carpoolName: "",
+                dateTime: new Date(),
+                destination: "",
+            }
+        )
     );
 
     const isEditing = !!existingCarpool;

--- a/packages/web/src/screens/carpool-screen.tsx
+++ b/packages/web/src/screens/carpool-screen.tsx
@@ -4,7 +4,7 @@ import { Redirect } from "react-router";
 import { CircularProgress, makeStyles } from "@material-ui/core";
 import { observer } from "mobx-react";
 
-import { AuthStore, CarpoolStore, DriverStore, CreateDriverDto } from "@carpool/core";
+import { AuthStore, CarpoolStore, DriverStore, CreateDriverDto, CarpoolDto } from "@carpool/core";
 import { CarpoolDetails, DriverList, DocumentHead, AppDialog, DriverForm } from "../components";
 
 const useStyles = makeStyles(theme => ({
@@ -27,6 +27,9 @@ export const CarpoolScreen: FunctionComponent<ICarpoolScreenProps> = observer(pr
     const { selectedCarpoolId, selectedCarpool, loading } = carpoolStore;
     const [ready, setReady] = useState(false);
     const [showDriverForm, setShowDriverForm] = useState(false);
+    const canUserEdit = Boolean(
+        authStore.user && selectedCarpool && authStore.user.id === selectedCarpool.createdById
+    );
 
     useEffect(() => {
         const selectId = async (id: string) => {
@@ -52,6 +55,12 @@ export const CarpoolScreen: FunctionComponent<ICarpoolScreenProps> = observer(pr
         handleToggleDriverForm();
     };
 
+    const handleSaveCarpoolDetails = async (carpoolDto: CarpoolDto) => {
+        if (canUserEdit) {
+            await carpoolStore.updateCarpool(carpoolDto, selectedCarpoolId);
+        }
+    };
+
     if (loading || !ready) {
         return <CircularProgress className={classes.progress} />;
     }
@@ -68,7 +77,14 @@ export const CarpoolScreen: FunctionComponent<ICarpoolScreenProps> = observer(pr
                 screenTitle={name}
                 description={`${name} ${destination} ${new Date(dateTime).toLocaleString()}`}
             />
-            <CarpoolDetails name={name} destination={destination} date={dateTime} />
+            <CarpoolDetails
+                name={name}
+                destination={destination}
+                date={dateTime}
+                canEdit={canUserEdit}
+                onSave={handleSaveCarpoolDetails}
+                saving={carpoolStore.saving}
+            />
             <DriverList
                 drivers={driverStore.drivers}
                 loading={driverStore.loading}

--- a/packages/web/src/screens/create-carpool-screen.tsx
+++ b/packages/web/src/screens/create-carpool-screen.tsx
@@ -2,8 +2,9 @@ import React, { FunctionComponent, Fragment, useState } from "react";
 import { Redirect } from "react-router";
 import { Card, Typography, Button, CircularProgress, makeStyles } from "@material-ui/core";
 import { observer } from "mobx-react";
+import { RouterStore } from "mobx-react-router";
 
-import { CarpoolStore } from "@carpool/core";
+import { CarpoolStore, CarpoolDto } from "@carpool/core";
 import { CarpoolForm, DocumentHead } from "../components";
 import toyCar from "../images/toy-car.svg";
 
@@ -35,21 +36,22 @@ export interface ICreateCarpoolScreenProps {
     isAuthenticated: boolean;
     onSignIn: () => void;
     carpoolStore: CarpoolStore;
+    routerStore: RouterStore;
 }
 
 export const CreateCarpoolScreen: FunctionComponent<ICreateCarpoolScreenProps> = observer(props => {
     const classes = useStyles();
-    const { initialized, isAuthenticated, onSignIn, carpoolStore } = props;
+    const { initialized, isAuthenticated, onSignIn, carpoolStore, routerStore } = props;
     const [redirectId, setRedirectId] = useState("");
 
-    const handleCreate = async (name: string, date: Date, address: string) => {
-        const carpool = await carpoolStore.createCarpool({
-            carpoolName: name,
-            destination: address,
-            dateTime: date,
-        });
+    const handleSave = async (carpoolDto: CarpoolDto) => {
+        const carpool = await carpoolStore.createCarpool(carpoolDto);
 
         setRedirectId(carpool.id);
+    };
+
+    const handleCancel = () => {
+        routerStore.replace({ pathname: "/" });
     };
 
     if (!!redirectId) {
@@ -67,7 +69,11 @@ export const CreateCarpoolScreen: FunctionComponent<ICreateCarpoolScreenProps> =
                 Create a Carpool
             </Typography>
             {isAuthenticated ? (
-                <CarpoolForm onCreate={handleCreate} creating={carpoolStore.creating} />
+                <CarpoolForm
+                    onSave={handleSave}
+                    onCancel={handleCancel}
+                    saving={carpoolStore.saving}
+                />
             ) : (
                 <Fragment>
                     <Typography variant="subtitle1" align="center">


### PR DESCRIPTION
Closes #58 

Updates include:
* Only carpool creator will be able to see the edit button 
* On toggle edit, displays the carpool form
* Carpool form was modified so that it can be used both by the create carpool page and in an editing context