### PR TITLE
167 code splitting for routes and large components

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -13,21 +13,21 @@ import {
     AuthLinks,
     Content,
     DocumentHead,
+    LoadingIndicator,
     UserMenu,
     UserMenuOption,
 } from "./components";
-import {
-    AuthScreen,
-    HomeScreen,
-    CreateCarpoolScreen,
-    CarpoolScreen,
-    UserCarpoolsScreen,
-    NotFoundScreen,
-    VerificationScreen,
-    ScreenMode,
-    ResetPasswordScreen,
-} from "./screens";
 import { getCarpoolPath } from "./utils";
+import { ScreenMode } from "./screens/verification-screen";
+
+const AuthScreen = React.lazy(() => import("./screens/auth-screen"));
+const CarpoolScreen = React.lazy(() => import("./screens/carpool-screen"));
+const CreateCarpoolScreen = React.lazy(() => import("./screens/create-carpool-screen"));
+const HomeScreen = React.lazy(() => import("./screens/home-screen"));
+const NotFoundScreen = React.lazy(() => import("./screens/not-found-screen"));
+const ResetPasswordScreen = React.lazy(() => import("./screens/reset-password-screen"));
+const UserCarpoolsScreen = React.lazy(() => import("./screens/user-carpools-screen"));
+const VerificationScreen = React.lazy(() => import("./screens/verification-screen"));
 
 const theme = createMuiTheme({
     palette: {
@@ -65,88 +65,96 @@ export class App extends Component<IAppProps> {
                 <DocumentHead />
                 <AppHeader rightOption={this.renderUserMenu()} />
                 <Content>
-                    <Switch>
-                        <Route path="/" exact={true} component={HomeScreen} />
-                        <Route
-                            path="/:displayName/carpools"
-                            exact={true}
-                            render={routeProps => (
-                                <UserCarpoolsScreen
-                                    authStore={authStore}
-                                    carpoolStore={carpoolStore}
-                                    {...routeProps}
-                                />
-                            )}
-                        />
-                        <Route
-                            path="/create"
-                            exact={true}
-                            render={_routeProps => (
-                                <CreateCarpoolScreen
-                                    initialized={authStore.initialized}
-                                    isAuthenticated={authStore.isAuthenticated}
-                                    carpoolStore={carpoolStore}
-                                    routerStore={routerStore}
-                                />
-                            )}
-                        />
-                        <Route
-                            path={getCarpoolPath(":name", ":id")}
-                            exact={true}
-                            render={routeProps => (
-                                <CarpoolScreen
-                                    authStore={authStore}
-                                    carpoolStore={carpoolStore}
-                                    driverStore={driverStore}
-                                    {...routeProps}
-                                />
-                            )}
-                        />
-                        <Route
-                            path="/verification"
-                            exact={true}
-                            render={_routeProps => (
-                                <VerificationScreen
-                                    authStore={authStore}
-                                    mode={ScreenMode.Verification}
-                                />
-                            )}
-                        />
-                        <Route
-                            path="/passwordreset"
-                            exact={true}
-                            render={_routeProps => (
-                                <VerificationScreen
-                                    authStore={authStore}
-                                    mode={ScreenMode.PasswordReset}
-                                />
-                            )}
-                        />
-                        <Route
-                            path="/sign-up"
-                            exact={true}
-                            render={routeProps => (
-                                <AuthScreen isSignUp={true} authStore={authStore} {...routeProps} />
-                            )}
-                        />
-                        <Route
-                            path="/sign-in"
-                            exact={true}
-                            render={routeProps => (
-                                <AuthScreen
-                                    isSignUp={false}
-                                    authStore={authStore}
-                                    {...routeProps}
-                                />
-                            )}
-                        />
-                        <Route
-                            path="/reset-password"
-                            exact={true}
-                            render={_routeProps => <ResetPasswordScreen authStore={authStore} />}
-                        />
-                        <Route component={NotFoundScreen} />
-                    </Switch>
+                    <React.Suspense fallback={<LoadingIndicator />}>
+                        <Switch>
+                            <Route path="/" exact={true} component={HomeScreen} />
+                            <Route
+                                path="/:displayName/carpools"
+                                exact={true}
+                                render={routeProps => (
+                                    <UserCarpoolsScreen
+                                        authStore={authStore}
+                                        carpoolStore={carpoolStore}
+                                        {...routeProps}
+                                    />
+                                )}
+                            />
+                            <Route
+                                path="/create"
+                                exact={true}
+                                render={_routeProps => (
+                                    <CreateCarpoolScreen
+                                        initialized={authStore.initialized}
+                                        isAuthenticated={authStore.isAuthenticated}
+                                        carpoolStore={carpoolStore}
+                                        routerStore={routerStore}
+                                    />
+                                )}
+                            />
+                            <Route
+                                path={getCarpoolPath(":name", ":id")}
+                                exact={true}
+                                render={routeProps => (
+                                    <CarpoolScreen
+                                        authStore={authStore}
+                                        carpoolStore={carpoolStore}
+                                        driverStore={driverStore}
+                                        {...routeProps}
+                                    />
+                                )}
+                            />
+                            <Route
+                                path="/verification"
+                                exact={true}
+                                render={_routeProps => (
+                                    <VerificationScreen
+                                        authStore={authStore}
+                                        mode={ScreenMode.Verification}
+                                    />
+                                )}
+                            />
+                            <Route
+                                path="/passwordreset"
+                                exact={true}
+                                render={_routeProps => (
+                                    <VerificationScreen
+                                        authStore={authStore}
+                                        mode={ScreenMode.PasswordReset}
+                                    />
+                                )}
+                            />
+                            <Route
+                                path="/sign-up"
+                                exact={true}
+                                render={routeProps => (
+                                    <AuthScreen
+                                        isSignUp={true}
+                                        authStore={authStore}
+                                        {...routeProps}
+                                    />
+                                )}
+                            />
+                            <Route
+                                path="/sign-in"
+                                exact={true}
+                                render={routeProps => (
+                                    <AuthScreen
+                                        isSignUp={false}
+                                        authStore={authStore}
+                                        {...routeProps}
+                                    />
+                                )}
+                            />
+                            <Route
+                                path="/reset-password"
+                                exact={true}
+                                render={_routeProps => (
+                                    <ResetPasswordScreen authStore={authStore} />
+                                )}
+                            />
+                            <Route component={NotFoundScreen} />
+                        </Switch>
+                    </React.Suspense>
                 </Content>
             </ThemeProvider>
         );

--- a/packages/web/src/components/carpool-details.tsx
+++ b/packages/web/src/components/carpool-details.tsx
@@ -1,12 +1,13 @@
 import React, { Fragment, useState } from "react";
 import {
-    IconButton,
-    Icon,
-    Card,
-    CardHeader,
-    CardContent,
-    Typography,
     Avatar,
+    Card,
+    CardContent,
+    CardHeader,
+    CircularProgress,
+    Icon,
+    IconButton,
+    Typography,
     makeStyles,
 } from "@material-ui/core";
 import amber from "@material-ui/core/colors/amber";
@@ -15,8 +16,9 @@ import { observer } from "mobx-react";
 
 import { CarpoolDto, UpsertCarpoolDto, getInitials } from "@carpool/core";
 import { ActionLink } from "./action-link";
-import { CarpoolForm } from "./carpool-form";
 import { NavLink } from "./nav-link";
+
+const CarpoolForm = React.lazy(() => import("./carpool-form"));
 
 const useStyles = makeStyles(theme => ({
     form: {
@@ -109,17 +111,19 @@ export const CarpoolDetails: React.FC<ICarpoolDetailsProps> = observer(props => 
         <Card>
             {editing && canEdit ? (
                 <div className={classes.form}>
-                    <CarpoolForm
-                        onSave={handleSave}
-                        onCancel={handleToggleEditing}
-                        saving={saving}
-                        existingCarpool={{
-                            carpoolName: name,
-                            destination: destination,
-                            dateTime: dateTime,
-                            description: description,
-                        }}
-                    />
+                    <React.Suspense fallback={<CircularProgress />}>
+                        <CarpoolForm
+                            onSave={handleSave}
+                            onCancel={handleToggleEditing}
+                            saving={saving}
+                            existingCarpool={{
+                                carpoolName: name,
+                                destination: destination,
+                                dateTime: dateTime,
+                                description: description,
+                            }}
+                        />
+                    </React.Suspense>
                 </div>
             ) : (
                 <Fragment>

--- a/packages/web/src/components/carpool-form.tsx
+++ b/packages/web/src/components/carpool-form.tsx
@@ -118,3 +118,5 @@ export const CarpoolForm: FunctionComponent<ICarpoolFormProps> = props => {
         </form>
     );
 };
+
+export default CarpoolForm;

--- a/packages/web/src/components/index.ts
+++ b/packages/web/src/components/index.ts
@@ -14,6 +14,7 @@ export * from "./driver-list";
 export * from "./email-sent";
 export * from "./form-actions";
 export * from "./loading-button";
+export * from "./loading-indicator";
 export * from "./nav-link";
 export * from "./not-found";
 export * from "./passenger-form";

--- a/packages/web/src/components/loading-indicator.tsx
+++ b/packages/web/src/components/loading-indicator.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { CircularProgress, makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        display: "flex",
+        justifyContent: "center",
+        marginTop: theme.spacing(2),
+    },
+}));
+
+export const LoadingIndicator: React.FC = () => {
+    const classes = useStyles();
+
+    return (
+        <div className={classes.root}>
+            <CircularProgress />
+        </div>
+    );
+};

--- a/packages/web/src/screens/auth-screen.tsx
+++ b/packages/web/src/screens/auth-screen.tsx
@@ -314,3 +314,5 @@ export const AuthScreen: React.FC<IAuthScreenProps> = observer(props => {
         </Container>
     );
 });
+
+export default AuthScreen;

--- a/packages/web/src/screens/carpool-screen.tsx
+++ b/packages/web/src/screens/carpool-screen.tsx
@@ -13,13 +13,13 @@ import {
     UpsertPassengerDto,
 } from "@carpool/core";
 import {
-    CarpoolDetails,
-    DriverList,
-    DocumentHead,
     AppDialog,
+    CarpoolDetails,
+    DocumentHead,
     DriverForm,
-    PassengerForm,
+    DriverList,
     FormActions,
+    PassengerForm,
 } from "../components";
 
 const useStyles = makeStyles(theme => ({
@@ -203,3 +203,5 @@ export const CarpoolScreen: FunctionComponent<ICarpoolScreenProps> = observer(pr
         </Container>
     );
 });
+
+export default CarpoolScreen;

--- a/packages/web/src/screens/create-carpool-screen.tsx
+++ b/packages/web/src/screens/create-carpool-screen.tsx
@@ -1,13 +1,15 @@
 import React, { FunctionComponent, Fragment, useState } from "react";
 import { Redirect } from "react-router";
-import { Card, Typography, CircularProgress, makeStyles } from "@material-ui/core";
+import { Card, CircularProgress, Typography, makeStyles } from "@material-ui/core";
 import { observer } from "mobx-react";
 import { RouterStore } from "mobx-react-router";
 
 import { CarpoolStore, CarpoolDto, UpsertCarpoolDto } from "@carpool/core";
-import { AuthLinks, CarpoolForm, DocumentHead } from "../components";
+import { AuthLinks, DocumentHead } from "../components";
 import { getCarpoolPath } from "../utils";
 import toyCar from "../images/toy-car.svg";
+
+const CarpoolForm = React.lazy(() => import("../components/carpool-form"));
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -69,11 +71,13 @@ export const CreateCarpoolScreen: FunctionComponent<ICreateCarpoolScreenProps> =
                 Create a Carpool
             </Typography>
             {isAuthenticated ? (
-                <CarpoolForm
-                    onSave={handleSave}
-                    onCancel={handleCancel}
-                    saving={carpoolStore.saving}
-                />
+                <React.Suspense fallback={<CircularProgress />}>
+                    <CarpoolForm
+                        onSave={handleSave}
+                        onCancel={handleCancel}
+                        saving={carpoolStore.saving}
+                    />
+                </React.Suspense>
             ) : (
                 <Fragment>
                     <Typography variant="subtitle1" align="center">

--- a/packages/web/src/screens/create-carpool-screen.tsx
+++ b/packages/web/src/screens/create-carpool-screen.tsx
@@ -88,3 +88,5 @@ export const CreateCarpoolScreen: FunctionComponent<ICreateCarpoolScreenProps> =
         </Card>
     );
 });
+
+export default CreateCarpoolScreen;

--- a/packages/web/src/screens/home-screen.tsx
+++ b/packages/web/src/screens/home-screen.tsx
@@ -75,3 +75,5 @@ export const HomeScreen: FunctionComponent = () => {
         </Grid>
     );
 };
+
+export default HomeScreen;

--- a/packages/web/src/screens/not-found-screen.tsx
+++ b/packages/web/src/screens/not-found-screen.tsx
@@ -4,3 +4,5 @@ import { NotFound } from "../components";
 export const NotFoundScreen: FunctionComponent = () => {
     return <NotFound />;
 };
+
+export default NotFoundScreen;

--- a/packages/web/src/screens/reset-password-screen.tsx
+++ b/packages/web/src/screens/reset-password-screen.tsx
@@ -119,3 +119,5 @@ export const ResetPasswordScreen: React.FC<IResetPasswordScreenProps> = props =>
         </Container>
     );
 };
+
+export default ResetPasswordScreen;

--- a/packages/web/src/screens/user-carpools-screen.tsx
+++ b/packages/web/src/screens/user-carpools-screen.tsx
@@ -150,3 +150,5 @@ export const UserCarpoolsScreen: FunctionComponent<IUserCarpoolsScreenProps> = o
         </Fragment>
     );
 });
+
+export default UserCarpoolsScreen;

--- a/packages/web/src/screens/verification-screen.tsx
+++ b/packages/web/src/screens/verification-screen.tsx
@@ -36,8 +36,8 @@ const styles = (theme: Theme) =>
         },
         loader: {
             display: "flex",
-            justifyContent: "center"
-        }
+            justifyContent: "center",
+        },
     });
 
 export interface IVerificationScreenProps extends WithStyles<typeof styles> {
@@ -63,7 +63,7 @@ class _VerificationScreen extends Component<IVerificationScreenProps, IVerificat
         readyForRedirect: false,
         newPassword: "",
         newPasswordDuplicate: "",
-        loading: false
+        loading: false,
     };
 
     private _token?;
@@ -93,12 +93,17 @@ class _VerificationScreen extends Component<IVerificationScreenProps, IVerificat
         e.preventDefault();
         try {
             this.setState({ loading: true });
-            await this.props.authStore.resetpassword(this._token, this._email, this.state.newPassword);
+            await this.props.authStore.resetpassword(
+                this._token,
+                this._email,
+                this.state.newPassword
+            );
+        } finally {
+            setTimeout(() => {
+                this.setState({ readyForRedirect: true });
+            }, 500);
         }
-        finally {
-            setTimeout(() => { this.setState({ readyForRedirect: true }) }, 500);
-        }
-    }
+    };
 
     public render() {
         const { classes } = this.props;
@@ -110,7 +115,7 @@ class _VerificationScreen extends Component<IVerificationScreenProps, IVerificat
                 <div className={classes.loader}>
                     <CircularProgress></CircularProgress>
                 </div>
-            )
+            );
         }
         if (this.props.mode === ScreenMode.Verification) {
             return (
@@ -126,7 +131,7 @@ class _VerificationScreen extends Component<IVerificationScreenProps, IVerificat
                 <DocumentHead screenTitle="Reset Password" />
                 <Typography variant="h6" align="center">
                     Password Reset
-                    </Typography>
+                </Typography>
                 <form onSubmit={this.handleSubmit}>
                     <TextField
                         className={classes.password}
@@ -160,7 +165,7 @@ class _VerificationScreen extends Component<IVerificationScreenProps, IVerificat
                             }
                         >
                             Change Password
-                    </Button>
+                        </Button>
                     </div>
                 </form>
             </Card>
@@ -169,3 +174,5 @@ class _VerificationScreen extends Component<IVerificationScreenProps, IVerificat
 }
 
 export const VerificationScreen = withStyles(styles)(_VerificationScreen);
+
+export default VerificationScreen;


### PR DESCRIPTION
Closes #167 

All screens are now imported lazily. A loading indicator will be displayed when navigating to those routes the first time until the screen component is fully loaded.