### PR TITLE
Explicit about resources in URL path

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -69,7 +69,7 @@ export class App extends Component<IAppProps> {
                         <Switch>
                             <Route path="/" exact={true} component={HomeScreen} />
                             <Route
-                                path="/:displayName/carpools"
+                                path="/users/:displayName/carpools"
                                 exact={true}
                                 render={routeProps => (
                                     <UserCarpoolsScreen
@@ -80,7 +80,7 @@ export class App extends Component<IAppProps> {
                                 )}
                             />
                             <Route
-                                path="/create"
+                                path="/carpools/create"
                                 exact={true}
                                 render={_routeProps => (
                                     <CreateCarpoolScreen
@@ -182,7 +182,9 @@ export class App extends Component<IAppProps> {
             case UserMenuOption.profile:
                 return;
             case UserMenuOption.carpools:
-                return routerStore.push({ pathname: `/${authStore.user!.displayName}/carpools` });
+                return routerStore.push({
+                    pathname: `/users/${authStore.user!.displayName}/carpools`,
+                });
             case UserMenuOption.signOut:
                 return this.handleSignOut();
         }

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -85,7 +85,7 @@ export const UserMenu: FunctionComponent<IUserMenuProps> = props => {
     return (
         <div>
             <div className={classes.buttons}>
-                <NavLink to="/create" className={classes.createLink}>
+                <NavLink to="/carpools/create" className={classes.createLink}>
                     <Button variant="outlined" color="secondary">
                         Create
                     </Button>

--- a/packages/web/src/screens/home-screen.tsx
+++ b/packages/web/src/screens/home-screen.tsx
@@ -63,7 +63,7 @@ export const HomeScreen: FunctionComponent = () => {
                     Save on gas, make new friends, reduce your carbon footprint, and get where you
                     need to go!
                 </Typography>
-                <NavLink to="/create" className={classes.createCarpool}>
+                <NavLink to="/carpools/create" className={classes.createCarpool}>
                     <Button variant="contained" color="primary" size="large">
                         Create a Carpool
                     </Button>

--- a/packages/web/src/utils/getCarpoolPath.ts
+++ b/packages/web/src/utils/getCarpoolPath.ts
@@ -6,5 +6,5 @@ import slugify from "slugify";
  * @param urlId - The carpool URL ID, not the GUID!
  */
 export const getCarpoolPath = (name: string, urlId: string) => {
-    return `/${urlId}/${slugify(name, { lower: true })}`;
+    return `/carpools/${urlId}/${slugify(name, { lower: true })}`;
 };


### PR DESCRIPTION
Closes #175 

Minor update to be more explicit about the resource being accessed in URL. E.g. accessing a specific carpool is now `/carpools/{carpoolId}/{carpoolName}`